### PR TITLE
[gradle] Bump net.denanu.BlockHighlighting:BlockHighlighting-1.19.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 	
 	// implementation group: 'org.javatuples', name: 'javatuples', version: '1.2'
 
-	modImplementation "net.denanu.BlockHighlighting:BlockHighlighting-1.19.2:1.0.0.1679062932638"
+	modImplementation "net.denanu.BlockHighlighting:BlockHighlighting-1.19.2:1.0.0.1679230689927"
 	modImplementation "net.denanu.DynamicSoundManager:DynamicSoundManager-1.19.2:1.0.0.1679062912920"
 	modImplementation "net.denanu.StoppableSound:StoppableSound-1.19.2:1.0.2.1679063961161"
 	modImplementation "fi.dy.masa.malilib:malilib-fabric-1.19.2:0.13.0"


### PR DESCRIPTION
Bumps net.denanu.BlockHighlighting:BlockHighlighting-1.19.2 from 1.0.0.1679062932638 to 1.0.0.1679230689927.

---
updated-dependencies:
- dependency-name: net.denanu.BlockHighlighting:BlockHighlighting-1.19.2 dependency-type: direct:production update-type: version-update:semver-patch ...